### PR TITLE
fixed MacOS X build issue, realpath not available

### DIFF
--- a/curl-compile-scripts/build_Android.sh
+++ b/curl-compile-scripts/build_Android.sh
@@ -10,8 +10,11 @@ else
   JOBS=2
 fi
 
-REL_SCRIPT_PATH="$(dirname $0)"
-SCRIPTPATH=$(realpath $REL_SCRIPT_PATH)
+#Get current directory
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=$(pwd)
+popd > /dev/null
+
 CURLPATH="$SCRIPTPATH/../curl"
 SSLPATH="$SCRIPTPATH/../openssl"
 


### PR DESCRIPTION
In MacOS X there is no realpath command, i modified it so i get the path from pwd. I modified the script for Android only.
