### PR TITLE
docs: fix simple typo, comparions -> comparison

### DIFF
--- a/prebuilt-with-ssl/iOS/include/curl/curlver.h
+++ b/prebuilt-with-ssl/iOS/include/curl/curlver.h
@@ -39,7 +39,7 @@
 #define LIBCURL_VERSION_PATCH 0
 
 /* This is the numeric version of the libcurl version number, meant for easier
-   parsing and comparions by programs. The LIBCURL_VERSION_NUM define will
+   parsing and comparison by programs. The LIBCURL_VERSION_NUM define will
    always follow this syntax:
 
          0xXXYYZZ


### PR DESCRIPTION
There is a small typo in prebuilt-with-ssl/iOS/include/curl/curlver.h.

Should read `comparison` rather than `comparions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md